### PR TITLE
update hugo repo

### DIFF
--- a/src/site/generators/hugo.md
+++ b/src/site/generators/hugo.md
@@ -9,7 +9,7 @@ license:
 templates:
   - Go
 description: A Fast and Flexible Static Site Generator.
-startertemplaterepo: https://github.com/netlify/victor-hugo
+startertemplaterepo: https://github.com/netlify-templates/hugo-quickstart
 twitter: GoHugoIO
 ---
 


### PR DESCRIPTION
this PR changes the repo that the Hugo "Deploy to Netlify" button uses on the generator page. The previous repo is now archived, which led to errors after selecting the button.